### PR TITLE
Fix invalid vercel header source pattern

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -51,7 +51,7 @@
       ]
     },
     {
-      "source": "/(.*\\.(html|htm))",
+      "source": "/:path*\\.(html|htm)",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
Fix Vercel header source pattern to use supported path parameter syntax.

The previous pattern `/(.*\\.(html|htm))` was not a valid Vercel source pattern due to problematic nested capture groups. The updated pattern `/:path*\\.(html|htm)` aligns with Vercel's path parameter syntax for header rules.

---
<a href="https://cursor.com/background-agent?bcId=bc-90db2fd7-9548-4fee-b2d4-700aa1136517">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-90db2fd7-9548-4fee-b2d4-700aa1136517">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

